### PR TITLE
Renderer, Canvasser, PubSub

### DIFF
--- a/web_client/src/canvasser/canvasser_actions.ts
+++ b/web_client/src/canvasser/canvasser_actions.ts
@@ -1,0 +1,48 @@
+import {
+  CanvasserCreateChannelActionArgsType,
+  CanvasserDefaultActionArgsType,
+  CanvasserRemoveSubscriptionActionArgsType,
+  CreateChannelActionType,
+  CreateSubscriptionActionType,
+  RemoveChannelActionType,
+  RemoveSubscriptionActionType,
+  SubscriptionRequestType,
+} from "./canvasser_utils.types";
+
+function createChannel<T>(
+  payload: CanvasserCreateChannelActionArgsType<T>,
+): CreateChannelActionType<T> {
+  return {
+    type: "CREATE_CHANNEL",
+    payload,
+  };
+}
+
+function removeChannel<T>(
+  payload: CanvasserDefaultActionArgsType<T>,
+): RemoveChannelActionType<T> {
+  return {
+    type: "REMOVE_CHANNEL",
+    payload,
+  };
+}
+
+function createSubscription<T>(
+  payload: SubscriptionRequestType<T>,
+): CreateSubscriptionActionType<T> {
+  return {
+    type: "CREATE_SUBSCRIPTION",
+    payload,
+  };
+}
+
+function removeSubscription<T>(
+  payload: CanvasserRemoveSubscriptionActionArgsType<T>,
+): RemoveSubscriptionActionType<T> {
+  return {
+    type: "REMOVE_SUBSCRIPTION",
+    payload,
+  };
+}
+
+export { createChannel, removeChannel, createSubscription, removeSubscription };

--- a/web_client/src/canvasser/canvasser_channel_reducer.ts
+++ b/web_client/src/canvasser/canvasser_channel_reducer.ts
@@ -1,0 +1,51 @@
+import {
+  ChannelMapType,
+  CREATE_CHANNEL,
+  CanvasserChannelActionTypes,
+  REMOVE_CHANNEL,
+} from "./canvasser_utils.types";
+
+function canvasserChannelReducer<T>(
+  channels: ChannelMapType<T>,
+  action: CanvasserChannelActionTypes<T>,
+): ChannelMapType<T> {
+  switch (action.type) {
+    case CREATE_CHANNEL: {
+      const { canvas } = action.payload;
+      const channelId = action.payload.channelId;
+      if (channels[channelId] != null) {
+        return channels;
+      }
+
+      const newChannel = {
+        channelId,
+        canvas,
+      };
+
+      return {
+        ...channels,
+        ...{ [channelId]: newChannel },
+      };
+    }
+    case REMOVE_CHANNEL: {
+      const { channelId } = action.payload;
+      if (channels[channelId] != null) {
+        return channels;
+      }
+      const modifiedChannels: ChannelMapType<T> = {};
+
+      for (const channelKey in channels) {
+        if (channelId === channelKey) {
+          continue;
+        }
+        modifiedChannels[channelKey] = channels[channelKey];
+      }
+
+      return modifiedChannels;
+    }
+  }
+
+  return channels;
+}
+
+export { canvasserChannelReducer };

--- a/web_client/src/canvasser/canvasser_subscriptions_reducer.ts
+++ b/web_client/src/canvasser/canvasser_subscriptions_reducer.ts
@@ -1,0 +1,68 @@
+import {
+  CanvasserSubscriptionActionTypes,
+  SubscriptionChannelMapType,
+  CREATE_SUBSCRIPTION,
+  REMOVE_SUBSCRIPTION,
+  SubscriptionsMapType,
+} from "./canvasser_utils.types";
+
+type CanvasserSubscriptionReducerArgs<T> = {
+  subscriptionChannels: SubscriptionChannelMapType<T>;
+  action: CanvasserSubscriptionActionTypes<T>;
+  subscriptionStub: number;
+};
+
+// update correct subscription format
+function canvasserSubscriptionsReducer<T>({
+  subscriptionChannels,
+  action,
+  subscriptionStub,
+}: CanvasserSubscriptionReducerArgs<T>): SubscriptionChannelMapType<T> {
+  switch (action.type) {
+    case CREATE_SUBSCRIPTION: {
+      const { channelId } = action.payload;
+      if (subscriptionChannels[channelId] != null) {
+        return subscriptionChannels;
+      }
+
+      const channelSubscriptions = subscriptionChannels[channelId];
+
+      const modifiedSubscriptions = {
+        ...subscriptionChannels,
+        ...{
+          [channelId]: {
+            ...channelSubscriptions,
+            ...{ [subscriptionStub]: action.payload },
+          },
+        },
+      };
+
+      return modifiedSubscriptions;
+    }
+    case REMOVE_SUBSCRIPTION: {
+      const { channelId, stub } = action.payload;
+      if (subscriptionChannels[channelId] == null) {
+        return subscriptionChannels;
+      }
+
+      const subscriptions = subscriptionChannels[channelId];
+
+      const modifiedSubscriptions: SubscriptionsMapType<T> = {};
+      const numStub = stub.toString();
+      for (const subStub in subscriptions) {
+        if (subStub === numStub) {
+          continue;
+        }
+        subscriptions[stub] = subscriptions[stub];
+      }
+
+      return {
+        ...subscriptionChannels,
+        ...{ [channelId]: modifiedSubscriptions },
+      };
+    }
+  }
+  return subscriptionChannels;
+}
+
+export { canvasserSubscriptionsReducer };

--- a/web_client/src/canvasser/canvasser_utils.ts
+++ b/web_client/src/canvasser/canvasser_utils.ts
@@ -1,0 +1,80 @@
+// Brian Taylor Vann
+// taylorvann.com
+
+import {
+  CanvasserChannelActionTypes,
+  CanvasserInterfaceType,
+  CanvasserStateType,
+  CanvasserSubscriptionActionTypes,
+  ChannelMapType,
+  SubscriptionChannelMapType,
+  SubscriptionsMapType,
+} from "./canvasser_utils.types";
+
+import { createSubscription } from "./canvasser_actions";
+
+import { canvasserSubscriptionsReducer } from "./canvasser_subscriptions_reducer";
+import { canvasserChannelReducer } from "./canvasser_channel_reducer";
+
+function dispatchToAllChannelSubscriptions<T>(
+  subscriptionChannels: SubscriptionChannelMapType<T>,
+  action: CanvasserChannelActionTypes<T>,
+): void {
+  const { channelId } = action.payload;
+  const subscriptionsMap: SubscriptionsMapType<T> | undefined =
+    subscriptionChannels[channelId];
+  if (subscriptionsMap == undefined) {
+    return;
+  }
+  for (const subscriptionsStub in subscriptionsMap) {
+    const subsciptionRequest = subscriptionsMap[subscriptionsStub];
+    subsciptionRequest.callback(action);
+  }
+}
+
+function canvasserDispatch<T>(
+  channels: ChannelMapType<T>,
+  subscriptionChannels: SubscriptionChannelMapType<T>,
+  action: CanvasserChannelActionTypes<T>,
+): ChannelMapType<T> {
+  const modifiedChannels = canvasserChannelReducer(channels, action);
+  dispatchToAllChannelSubscriptions(subscriptionChannels, action);
+
+  return modifiedChannels;
+}
+
+function createCanvasserService<T>(): CanvasserInterfaceType<T> {
+  let channels: ChannelMapType<T> = {};
+  let subscriptionChannels = {};
+  let subscriptionStub = 0;
+
+  function dispatch(action: CanvasserChannelActionTypes<T>): void {
+    channels = canvasserDispatch(channels, subscriptionChannels, action);
+  }
+
+  function getState(): CanvasserStateType<T> {
+    return { channels, subscriptionChannels };
+  }
+
+  // we've subscribed an agnostic callback
+  function subscribe(
+    channel: keyof T,
+    callback: (action: CanvasserChannelActionTypes<T>) => void,
+  ): void {
+    subscriptionChannels = canvasserSubscriptionsReducer({
+      subscriptionChannels,
+      action: createSubscription({ channelId: channel, callback }),
+      subscriptionStub,
+    });
+
+    subscriptionStub += 1;
+  }
+
+  return {
+    dispatch,
+    getState,
+    subscribe,
+  };
+}
+
+export { createCanvasserService };

--- a/web_client/src/canvasser/canvasser_utils.types.ts
+++ b/web_client/src/canvasser/canvasser_utils.types.ts
@@ -1,0 +1,102 @@
+// Brian Taylor Vann
+
+// canvasser constants
+export const CREATE_SUBSCRIPTION = "CREATE_SUBSCRIPTION";
+export const REMOVE_SUBSCRIPTION = "REMOVE_SUBSCRIPTION";
+export const CREATE_CHANNEL = "CREATE_CHANNEL";
+export const REMOVE_CHANNEL = "REMOVE_CHANNEL";
+
+// canvasser types
+export type ChannelType<T> = {
+  channelId: keyof T;
+  canvas: HTMLCanvasElement;
+};
+
+export type ChannelMapType<T> = {
+  [K in keyof T]?: ChannelType<T>;
+};
+
+// canvasser channel action creator types
+export type CreateChannelActionType<T> = {
+  type: typeof CREATE_CHANNEL;
+  payload: {
+    channelId: keyof T;
+    canvas: HTMLCanvasElement;
+  };
+};
+
+export type RemoveChannelActionType<T> = {
+  type: typeof REMOVE_CHANNEL;
+  payload: {
+    channelId: keyof T;
+  };
+};
+
+export type CanvasserChannelActionTypes<T> =
+  | CreateChannelActionType<T>
+  | RemoveChannelActionType<T>;
+
+// canvasser subscription action creator types
+export type SubscriptionRequestType<T> = {
+  channelId: keyof T;
+  callback: (action: CanvasserChannelActionTypes<T>) => void;
+};
+
+export type CreateSubscriptionActionType<T> = {
+  type: typeof CREATE_SUBSCRIPTION;
+  payload: SubscriptionRequestType<T>;
+};
+
+export type RemoveSubscriptionActionType<T> = {
+  type: typeof REMOVE_SUBSCRIPTION;
+  payload: {
+    channelId: keyof T;
+    stub: number;
+  };
+};
+
+export type CanvasserSubscriptionActionTypes<T> =
+  | CreateSubscriptionActionType<T>
+  | RemoveSubscriptionActionType<T>;
+
+// canvasser reducer types
+export type SubscriptionsMapType<T> = {
+  [key: number]: SubscriptionRequestType<T>;
+};
+
+export type SubscriptionChannelMapType<T> = {
+  [K in keyof T]?: SubscriptionsMapType<T>;
+};
+
+// canvasser state
+export type CanvasserStateType<T> = Readonly<{
+  channels: ChannelMapType<T>;
+  subscriptionChannels: SubscriptionChannelMapType<T>;
+}>;
+
+// canvasser interface
+export type CanvasserDispatchType<T> = (
+  action: CanvasserChannelActionTypes<T>,
+) => void;
+export type CanvasserGetStateType<T> = () => CanvasserStateType<T>;
+export type CanvasserSubscriptionType<T> = (
+  channelId: keyof T,
+  callback: (action: CanvasserChannelActionTypes<T>) => void,
+) => void;
+
+export type CanvasserInterfaceType<T> = {
+  dispatch: CanvasserDispatchType<T>;
+  getState: CanvasserGetStateType<T>;
+  subscribe: CanvasserSubscriptionType<T>;
+};
+
+// action args
+export type CanvasserDefaultActionArgsType<T> = { channelId: keyof T };
+export type CanvasserCreateChannelActionArgsType<T> = {
+  channelId: keyof T;
+  canvas: HTMLCanvasElement;
+};
+export type CanvasserRemoveSubscriptionActionArgsType<T> = {
+  channelId: keyof T;
+  stub: number;
+};

--- a/web_client/src/pubsub/pubsub_service_utils.ts
+++ b/web_client/src/pubsub/pubsub_service_utils.ts
@@ -1,11 +1,3 @@
-// Brian Taylor Vann
-// taylorvann dot com
-
-// PubSub Service Utils
-// Create a message hub and keep parts of an application separated
-// through messaging.
-// Provide a map of {[channels]: actionTypes}.
-
 import {
   AddSubToChannelArgsType,
   PublishToAllSubsArgsType,
@@ -65,20 +57,19 @@ function removeSubscriptionFromChannel<T>({
   };
 }
 
+// Service oriented
 // dispatch all subscriptions
 function publishToAllSubscriptions<T>({
   pubsubs,
   channel,
   action,
 }: PublishToAllSubsArgsType<T>): void {
-  console.log("publish to all subscriptions");
   const serviceSubs: PubSubChannelMapType<T[keyof T]> | undefined =
     pubsubs[channel];
 
   if (serviceSubs == null) {
     return;
   }
-  console.log("channel subs:", serviceSubs);
   for (let stub in serviceSubs) {
     const subCallback = serviceSubs[stub];
     subCallback(action);
@@ -109,6 +100,7 @@ function createPubSubService<T>(): PubSubInterfaceType<T> {
         });
       };
     },
+    // from messaging service to all local subscriptions
     dispatch: (channel, action) => {
       publishToAllSubscriptions({ pubsubs, channel, action });
     },

--- a/web_client/src/pubsub/pubsub_service_utils.ts
+++ b/web_client/src/pubsub/pubsub_service_utils.ts
@@ -1,11 +1,19 @@
+// Brian Taylor Vann
+// taylorvann dot com
+
+// PubSub Service Utils
+// Create a message hub and keep parts of an application separated
+// through messaging.
+// Provide a map of {[channels]: actionTypes}.
+
 import {
   AddSubToChannelArgsType,
-  RemoveSubToChannelArgsType,
-  UnsubscribeType,
-  PubSubInterfaceType,
   PublishToAllSubsArgsType,
   PubSubChannelMapType,
+  PubSubInterfaceType,
   PubSubMapType,
+  RemoveSubToChannelArgsType,
+  UnsubscribeType,
 } from "./pubsub_service_utils.types";
 
 // add subscription
@@ -39,16 +47,13 @@ function removeSubscriptionFromChannel<T>({
     return pubsubs;
   }
 
-  channelSubs;
-
   const modifiedChannelSubs: PubSubChannelMapType<T[keyof T]> = {};
   const subStubStr = subscriptionStub.toString();
   for (let stub in channelSubs) {
     if (subStubStr === stub) {
       continue;
     }
-    channelSubs[stub];
-    // modifiedChannelSubs[stub] = channelSubs[stub];
+    modifiedChannelSubs[stub] = channelSubs[stub];
   }
   return {
     ...pubsubs,
@@ -61,7 +66,7 @@ function removeSubscriptionFromChannel<T>({
 }
 
 // dispatch all subscriptions
-function publishToAllSubscriptions<T, R>({
+function publishToAllSubscriptions<T>({
   pubsubs,
   channel,
   action,
@@ -82,16 +87,11 @@ function publishToAllSubscriptions<T, R>({
 
 // create a PubSub Service
 function createPubSubService<T>(): PubSubInterfaceType<T> {
-  console.log("created pub sub service");
   let subscriptionStub: number = -1;
-  let pubsubs: PubSubMapType<T> = {};
+  let pubsubs = {};
 
   return {
-    subscribe: (
-      channel: keyof T,
-      callback: (action: T[keyof T]) => void,
-    ): UnsubscribeType => {
-      console.log("pubsub subscribe called");
+    subscribe: (channel, callback): UnsubscribeType => {
       subscriptionStub += 1;
       pubsubs = addSubscriptionToChannel({
         pubsubs,
@@ -109,12 +109,7 @@ function createPubSubService<T>(): PubSubInterfaceType<T> {
         });
       };
     },
-
-    // this isn't a callback, it's an action
-    // we have a map of callback types,
-    // we need a map of potential callback actions
-    dispatch: (channel: keyof T, action: T[keyof T]) => {
-      console.log("dispatched:", channel, action);
+    dispatch: (channel, action) => {
       publishToAllSubscriptions({ pubsubs, channel, action });
     },
     getState: () => {

--- a/web_client/src/pubsub/pubsub_service_utils.types.ts
+++ b/web_client/src/pubsub/pubsub_service_utils.types.ts
@@ -27,7 +27,7 @@ export type PublishToAllSubsArgsType<M> = {
 
 export type UnsubscribeType = () => void;
 
-export type SubscribeType<T> = (
+export type SubscribeType = <T>(
   channel: keyof T,
   callback: (action: T[keyof T]) => void,
 ) => UnsubscribeType;
@@ -37,7 +37,7 @@ export type DispatchType<T> = (channel: keyof T, action: T[keyof T]) => void;
 export type GetStateType<T> = () => PubSubMapType<T>;
 
 export type PubSubInterfaceType<M> = Readonly<{
-  subscribe: SubscribeType<M>;
+  subscribe: SubscribeType;
   dispatch: DispatchType<M>;
   getState: GetStateType<M>;
 }>;

--- a/web_client/src/renderer/renderer_actions.ts
+++ b/web_client/src/renderer/renderer_actions.ts
@@ -1,0 +1,36 @@
+import {
+  RendererCreateChannelActionArgsType,
+  RendererDefaultActionArgsType,
+  CreateChannelActionType,
+  RemoveChannelActionType,
+  UpdateChannelActionType,
+} from "./renderer_utils.types";
+
+function createChannel<T>(
+  payload: RendererCreateChannelActionArgsType<T>,
+): CreateChannelActionType<T> {
+  return {
+    type: "CREATE_CHANNEL",
+    payload,
+  };
+}
+
+function updateChannel<T>(
+  payload: RendererDefaultActionArgsType<T>,
+): UpdateChannelActionType<T> {
+  return {
+    type: "UPDATE_CHANNEL",
+    payload,
+  };
+}
+
+function removeChannel<T>(
+  payload: RendererDefaultActionArgsType<T>,
+): RemoveChannelActionType<T> {
+  return {
+    type: "REMOVE_CHANNEL",
+    payload,
+  };
+}
+
+export { createChannel, updateChannel, removeChannel };

--- a/web_client/src/renderer/renderer_channel_reducer.ts
+++ b/web_client/src/renderer/renderer_channel_reducer.ts
@@ -1,0 +1,71 @@
+import {
+  ChannelMapType,
+  ChannelType,
+  CREATE_CHANNEL,
+  RendererChannelActionTypes,
+  REMOVE_CHANNEL,
+} from "./renderer_utils.types";
+
+import * as THREE from "three";
+
+import { updateRendererDimensions, PIXEL_RATIO } from "./renderer_utils";
+
+function rendererChannelReducer<T>(
+  channels: ChannelMapType<T>,
+  action: RendererChannelActionTypes<T>,
+): ChannelMapType<T> {
+  switch (action.type) {
+    case CREATE_CHANNEL: {
+      const { canvas } = action.payload;
+      const channelId = action.payload.channelId;
+      if (channels[channelId] != null) {
+        return channels;
+      }
+
+      canvas.width = Math.floor(canvas.clientWidth * PIXEL_RATIO);
+      canvas.height = Math.floor(canvas.clientHeight * PIXEL_RATIO);
+
+      // instantiate renderer
+      const renderer = new THREE.WebGLRenderer({
+        canvas: action.payload.canvas,
+      });
+
+      // update dimensions
+      updateRendererDimensions(canvas, renderer);
+
+      console.log("created element");
+      console.log(canvas);
+      console.log(renderer);
+      const newChannel: ChannelType<keyof T> = {
+        channelId,
+        canvas,
+        renderer,
+      };
+
+      return {
+        ...channels,
+        ...{ [channelId]: newChannel },
+      };
+    }
+    case REMOVE_CHANNEL: {
+      const { channelId } = action.payload;
+      if (channels[channelId] != null) {
+        return channels;
+      }
+      const modifiedChannels: ChannelMapType<T> = {};
+
+      for (const channelKey in channels) {
+        if (channelId === channelKey) {
+          continue;
+        }
+        modifiedChannels[channelKey] = channels[channelKey];
+      }
+
+      return modifiedChannels;
+    }
+  }
+
+  return channels;
+}
+
+export { rendererChannelReducer };

--- a/web_client/src/renderer/renderer_utils.ts
+++ b/web_client/src/renderer/renderer_utils.ts
@@ -1,0 +1,77 @@
+// Brian Taylor Vann
+// taylorvann dot com
+
+import { Renderer } from "three";
+import {
+  RendererChannelActionTypes,
+  RendererInterfaceType,
+  RendererStateType,
+  ChannelMapType,
+} from "./renderer_utils.types";
+
+export const PIXEL_RATIO = window.devicePixelRatio;
+
+import { rendererChannelReducer } from "./renderer_channel_reducer";
+
+function updateRendererDimensions<T>(
+  canvas: HTMLCanvasElement,
+  renderer: Renderer,
+) {
+  const { clientWidth, clientHeight } = canvas;
+
+  const width = Math.floor(clientWidth * PIXEL_RATIO);
+  const height = Math.floor(clientHeight * PIXEL_RATIO);
+
+  canvas.width = width;
+  canvas.height = height;
+  renderer.setSize(width, height, false);
+}
+
+function updateChannel<T>(
+  channels: ChannelMapType<T>,
+  action: RendererChannelActionTypes<T>,
+) {
+  const { channelId } = action.payload;
+
+  const channel = channels[channelId];
+  if (channel == null) {
+    return;
+  }
+
+  const canvas = channel.canvas;
+  const renderer = channel.renderer;
+  if (canvas == null || renderer == null) {
+    return;
+  }
+
+  // update canvas size and stuff
+  updateRendererDimensions(canvas, renderer);
+}
+
+function createRendererService<T>(): RendererInterfaceType<T> {
+  let channels: ChannelMapType<T> = {};
+
+  function dispatch(action: RendererChannelActionTypes<T>): void {
+    if (action.type === "RENDER_CHANNEL") {
+      // render channel
+      return;
+    }
+    if (action.type === "UPDATE_CHANNEL") {
+      // update dimensions
+      updateChannel(channels, action);
+      return;
+    }
+    channels = rendererChannelReducer(channels, action);
+  }
+
+  function getState(): RendererStateType<T> {
+    return { channels };
+  }
+
+  return {
+    dispatch,
+    getState,
+  };
+}
+
+export { createRendererService, updateRendererDimensions };

--- a/web_client/src/renderer/renderer_utils.types.ts
+++ b/web_client/src/renderer/renderer_utils.types.ts
@@ -1,0 +1,84 @@
+// Brian Taylor Vann
+
+import { Renderer } from "three";
+
+// Renderer constants
+export const CREATE_SUBSCRIPTION = "CREATE_SUBSCRIPTION";
+export const REMOVE_SUBSCRIPTION = "REMOVE_SUBSCRIPTION";
+export const CREATE_CHANNEL = "CREATE_CHANNEL";
+export const UPDATE_CHANNEL = "UPDATE_CHANNEL";
+export const REMOVE_CHANNEL = "REMOVE_CHANNEL";
+export const RENDER_CHANNEL = "RENDER_CHANNEL";
+
+// Renderer types
+export type ChannelType<K> = {
+  channelId: K;
+  canvas: HTMLCanvasElement;
+  renderer: THREE.Renderer;
+};
+
+export type ChannelMapType<T> = {
+  [K in keyof T]?: ChannelType<K>;
+};
+
+// Renderer channel action creator types
+export type CreateChannelActionType<T> = {
+  type: typeof CREATE_CHANNEL;
+  payload: {
+    channelId: keyof T;
+    canvas: HTMLCanvasElement;
+  };
+};
+
+export type UpdateChannelActionType<T> = {
+  type: typeof UPDATE_CHANNEL;
+  payload: {
+    channelId: keyof T;
+  };
+};
+
+export type RemoveChannelActionType<T> = {
+  type: typeof REMOVE_CHANNEL;
+  payload: {
+    channelId: keyof T;
+  };
+};
+
+export type RenderChannelActionType<T> = {
+  type: typeof RENDER_CHANNEL;
+  payload: {
+    channelId: keyof T;
+  };
+};
+
+export type RendererChannelActionTypes<T> =
+  | CreateChannelActionType<T>
+  | UpdateChannelActionType<T>
+  | RemoveChannelActionType<T>
+  | RenderChannelActionType<T>;
+
+// Renderer subscription action creator types
+
+// Renderer state
+export type RendererStateType<T> = Readonly<{
+  channels: ChannelMapType<T>;
+}>;
+
+// Renderer interface
+export type RendererDispatchType<T> = (
+  action: RendererChannelActionTypes<T>,
+) => void;
+export type RendererGetStateType<T> = () => RendererStateType<T>;
+
+export type RendererInterfaceType<T> = {
+  dispatch: RendererDispatchType<T>;
+  getState: RendererGetStateType<T>;
+  // subscribe: RendererSubscriptionType<T>;
+};
+
+// action args
+export type RendererDefaultActionArgsType<T> = { channelId: keyof T };
+export type RendererCreateChannelActionArgsType<T> = {
+  channelId: keyof T;
+  canvas: HTMLCanvasElement;
+};


### PR DESCRIPTION
Services are being kept separate

Canvasser holds real DOM canvas elements.
Renderer provides a specific function: taking a scene and a camera abstraction and rendering them.
PubSub lets services stay completely separate from eachother. Flux style "actions" govern behavior.
 