### PR TITLE
Create worker for messaging between View and Model

### DIFF
--- a/web_client/src/workers/worker_bridge.worker.d.ts
+++ b/web_client/src/workers/worker_bridge.worker.d.ts
@@ -1,0 +1,7 @@
+declare module "worker_bridge.worker" {
+  class WebpackWorker extends Worker {
+    constructor();
+  }
+
+  export default WebpackWorker;
+}

--- a/web_client/src/workers/worker_bridge.worker.ts
+++ b/web_client/src/workers/worker_bridge.worker.ts
@@ -1,0 +1,18 @@
+// Brian Taylor Vann
+
+// WorkerBridge is a messaging system between the main thread
+// and auxillary threads.
+
+// TODO DANGEROUS As of 2020, webpack asks developers to cast self as any
+
+// eslint-disable-next-line
+const ctx: Worker = self as any;
+
+console.log("hello from a webworker");
+
+ctx.addEventListener("message", (e: MessageEvent) => {
+  console.log("yo we got your message!");
+  console.log(e.data);
+});
+
+ctx.postMessage({ whats: "good" });

--- a/web_client/src/workers/worker_utils.ts
+++ b/web_client/src/workers/worker_utils.ts
@@ -1,0 +1,32 @@
+// Brian Taylor Vann
+
+// DANGEROUS: Ignore typsecript warnings about not being a module.
+
+// The WorkerBridge import is a symbolic link to an actual worker
+// created through Webpack as a blob.
+
+// the next two warngins disable typescript and eslint ignores
+// eslint-disable-next-line
+// @ts-ignore
+import * as WorkerBridge from "./worker_bridge.worker";
+
+const createWorkerInterfaceInstance = (): { getState: () => void } => {
+  console.log("attempting to create worker");
+  console.log(WorkerBridge);
+
+  const worker: Worker = new WorkerBridge();
+  worker.addEventListener("message", (e: MessageEvent) => {
+    console.log("received message:");
+    console.log(e.data);
+  });
+
+  worker.postMessage({ hello: "hello, world" });
+
+  return {
+    getState: (): void => {
+      console.log("yoooo its a worker");
+    },
+  };
+};
+
+export { createWorkerInterfaceInstance };


### PR DESCRIPTION
Create a central worker to parse messages between UI and application logic.

The View ViewModel layer will interact with workers.
We can keep application state, expensive logic, and asynchronous fetches separate from our View now